### PR TITLE
scssphp version change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "advanced-custom-fields/advanced-custom-fields-pro": "^5.9",
     "yahnis-elsts/plugin-update-checker": "^4.11",
-    "scssphp/scssphp": "^1.10.0"
+    "scssphp/scssphp": "1.0.9"
   },
   "repositories": [
     {


### PR DESCRIPTION
version needs to match 1.0.9 (the version in WitCommander) to resolve conflicts that occur on activation when this plugin runs scssphp ^1.10.0